### PR TITLE
Support renders that reference multiple templates

### DIFF
--- a/test/fixtures/views/users/_description.html.erb
+++ b/test/fixtures/views/users/_description.html.erb
@@ -1,0 +1,1 @@
+This is a description

--- a/test/fixtures/views/users/_foo.html.erb
+++ b/test/fixtures/views/users/_foo.html.erb
@@ -1,0 +1,3 @@
+<div class="bar">
+  <%= yield %>
+</div>

--- a/test/fixtures/views/users/show.html.erb
+++ b/test/fixtures/views/users/show.html.erb
@@ -1,3 +1,3 @@
-<% layout "foo" %>
-
 <%= render "users/user", user: @user %>
+
+<%= render partial: "users/description", layout: "foo", locals: { bar: true } %>

--- a/test/template_parser_test.rb
+++ b/test/template_parser_test.rb
@@ -6,10 +6,11 @@ module ActionviewPrecompiler
       template = parse_template("users/show.html.erb")
       assert_equal "show.html.erb", template.basename
       assert_kind_of ActionView::Template::Handlers::ERB, template.handler
+
       renders =  template.render_calls
-      assert_equal 1, renders.length
-      assert_equal "users/_user", renders[0].virtual_path
-      assert_equal [:user], renders[0].locals_keys
+      assert_equal 3, renders.length
+      assert_equal ["users/_user", "users/_description", "users/_foo"], renders.map(&:virtual_path)
+      assert_equal [[:user], [:bar], [:bar]], renders.map(&:locals_keys)
     end
 
     def test_parsing_partial


### PR DESCRIPTION
Add support for render calls that reference more than one template. This requires returning an array of RenderCalls per render node. Expected paths for layout lookup are as follows:

- `layout "foo"` or `layout :foo` in a controller -> `layouts/foo`
- `render "bar", layout: "foo"` in a controller -> `layouts/foo`
- `<%= render layout: "foos/foo" %>` in a view -> `foos/_foo`
- `<%= render partial: "bar", layout: "foos/foo" %>` in a view -> `foos/_foo`

ActionView does some intelligent template lookup that is not addressed by this PR. With these changes, a render like `<%= render partial: "users/user", layout: "foo" %>` will lookup `users/_foo` by using the same prefix as the partial. Instead, we should use the path this render call was found in. For example, `<%= render partial: "other/user", layout: "foo" %>` in app/views/users/show.html.erb should use `users/foo`. Leaving as todo as we'll need to add filepath to the node object to support this.