### PR TITLE
Do not try to precompile layout when symbol

### DIFF
--- a/lib/actionview_precompiler/render_parser.rb
+++ b/lib/actionview_precompiler/render_parser.rb
@@ -72,7 +72,7 @@ module ActionviewPrecompiler
     def parse_layout(node)
       return nil unless from_controller?
 
-      template = parse_str(node.argument_nodes[0]) || parse_sym(node.argument_nodes[0])
+      template = parse_str(node.argument_nodes[0])
       return nil unless template
 
       virtual_path = layout_to_virtual_path(template)

--- a/test/fixtures/controllers/users_controller.rb
+++ b/test/fixtures/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
 
-  layout :site
+  layout "site"
 
   def show
     render "show"

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -96,6 +96,13 @@ module ActionviewPrecompiler
       assert_equal 0, renders.length
     end
 
+    def test_ignores_layout_when_symbol
+      renders = parse_render_calls(%q{render partial: "users/user", layout: :foobar, locals: { buzz: true }})
+      assert_equal 1, renders.length
+      assert_equal ["users/_user"], renders.map(&:virtual_path)
+      assert_equal [[:buzz]], renders.map(&:locals_keys)
+    end
+
     def test_finds_simple_render_with_locals
       renders = parse_render_calls(%q{render "users/user", user: @user})
       assert_equal 1, renders.length
@@ -201,11 +208,9 @@ module ActionviewPrecompiler
       assert_equal [], renders[0].locals_keys
     end
 
-    def test_layout_with_symbol_from_controller
+    def test_layout_ignores_symbols_from_controller
       renders = parse_render_calls(%q{layout :foobar }, from_controller: true)
-      assert_equal 1, renders.length
-      assert_equal "layouts/foobar", renders[0].virtual_path
-      assert_equal [], renders[0].locals_keys
+      assert_equal 0, renders.length
     end
 
     def test_render_with_layout_from_controller


### PR DESCRIPTION
When layout is called with a symbol, Rails calls
the [method specified by the symbol](https://github.com/rails/rails/blob/5cfd58bbfb8425ab1931c618d98b649bab059ce6/actionview/lib/action_view/layouts.rb#L252) to get the
template name. Do not attempt to precompile.