### PR TITLE
Handle trailing comma in render calls

### DIFF
--- a/lib/actionview_precompiler/ast_parser/ripper.rb
+++ b/lib/actionview_precompiler/ast_parser/ripper.rb
@@ -34,7 +34,11 @@ module ActionviewPrecompiler
       def argument_nodes
         raise unless fcall?
         return [] if self[1].nil?
-        self[1][0...-1]
+        if self[1].last == false || self[1].last.type == :vcall
+          self[1][0...-1]
+        else
+          self[1][0..-1]
+        end
       end
 
       def string?

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -77,6 +77,14 @@ module ActionviewPrecompiler
       assert_equal [], render.locals_keys
     end
 
+    def test_find_renders_with_block
+      renders = parse_render_calls(%q{render("discussions/sidebar", discussion: discussion) {} })
+
+      assert_equal 1, renders.length
+      assert_equal "discussions/_sidebar", renders[0].virtual_path
+      assert_equal [:discussion], renders[0].locals_keys
+    end
+
     def test_render_partial_with_layout
       renders = parse_render_calls(%q{render partial: "users/user", layout: "foobar", locals: { buzz: true }})
       assert_equal 2, renders.length
@@ -129,6 +137,14 @@ module ActionviewPrecompiler
       assert_equal 1, renders.length
       assert_equal "users/_user", renders[0].virtual_path
       assert_equal [:user], renders[0].locals_keys
+    end
+
+    def test_finds_renders_with_trailing_comma
+      renders = parse_render_calls(%q{render("discussions/sidebar", discussion: discussion,)})
+
+      assert_equal 1, renders.length
+      assert_equal "discussions/_sidebar", renders[0].virtual_path
+      assert_equal [:discussion], renders[0].locals_keys
     end
 
     def test_finds_render_with_local_variables


### PR DESCRIPTION
There is a final false in argument_nodes which is typicaly skiped,
but when there is a trailing comma and you are parsing with ripper, instead of a trailing comma, ripper returns the arguement node we want in the last argument.

The same structure appears when the last argument is a proc like `&proc`.
This keeps that last argument in cases where there is a trailing comma or a last argument proc.

`render("discussions/sidebar", discussion: discussion,)`

```
[:program,
 [[:method_add_arg,
   [:fcall, [:@ident, "render", [1, 0]]],
   [:arg_paren,
    [[:string_literal,
      [:string_content, [:@tstring_content, "discussions/sidebar", [1, 8]]]],
     [:bare_assoc_hash,
      [[:assoc_new,
        [:@label, "discussion:", [1, 30]],
        [:vcall, [:@ident, "discussion", [1, 42]]]]]]]]]]]
```

`render("discussions/sidebar", discussion: discussion)`

```
[:program,
 [[:method_add_arg,
   [:fcall, [:@ident, "render", [1, 0]]],
   [:arg_paren,
    [:args_add_block,
     [[:string_literal,
       [:string_content, [:@tstring_content, "discussions/sidebar", [1, 8]]]],
      [:bare_assoc_hash,
       [[:assoc_new,
         [:@label, "discussion:", [1, 30]],
         [:vcall, [:@ident, "discussion", [1, 42]]]]]]],
     false]]]]]
```