### PR TITLE
Allow whitespace before parens

### DIFF
--- a/lib/actionview_precompiler/ast_parser/ripper.rb
+++ b/lib/actionview_precompiler/ast_parser/ripper.rb
@@ -182,6 +182,10 @@ module ActionviewPrecompiler
       def on_arg_paren(content)
         content
       end
+
+      def on_paren(content)
+        content
+      end
     end
 
     extend self

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -139,6 +139,20 @@ module ActionviewPrecompiler
       assert_equal [:user], renders[0].locals_keys
     end
 
+    def test_finds_render_with_method_on_instance_variable
+      renders = parse_render_calls(%q{render @user.events})
+      assert_equal 1, renders.length
+      assert_equal "events/_event", renders[0].virtual_path
+      assert_equal [:event], renders[0].locals_keys
+    end
+
+    def test_finds_render_with_extra_whitespace
+      renders = parse_render_calls(%q{render ( @message.events )})
+      assert_equal 1, renders.length
+      assert_equal "events/_event", renders[0].virtual_path
+      assert_equal [:event], renders[0].locals_keys
+    end
+
     def test_finds_renders_with_trailing_comma
       renders = parse_render_calls(%q{render("discussions/sidebar", discussion: discussion,)})
 


### PR DESCRIPTION
This allows rendeer calls like `render (@user)` this creates the sexp type of `paren` rather then `arg_paren` which is returned from render calls like `render(@user)`.
Now both of these cases are handled the same.