### PR TITLE
Avoid array return

### DIFF
--- a/lib/actionview_precompiler/ast_parser/jruby.rb
+++ b/lib/actionview_precompiler/ast_parser/jruby.rb
@@ -109,15 +109,14 @@ module ActionviewPrecompiler
       return [] unless node?(node)
       renders = node.children.flat_map { |c| extract_render_nodes(c) }
 
-      is_render, method = render_call?(node)
-      renders << [method, node] if is_render
+      method_name = render_call?(node)
+      renders << [method_name, node] if method_name
 
       renders
     end
 
     def render_call?(node)
-      METHODS_TO_PARSE.each { |m| return [true, m] if fcall?(node, m) }
-      false
+      METHODS_TO_PARSE.detect { |m| fcall?(node, m) }
     end
   end
 end

--- a/lib/actionview_precompiler/ast_parser/ruby26.rb
+++ b/lib/actionview_precompiler/ast_parser/ruby26.rb
@@ -143,16 +143,15 @@ module ActionviewPrecompiler
           queue << child if node?(child)
         end
 
-        is_render, method = render_call?(node)
-        renders << [method, node] if is_render
+        method_name = render_call?(node)
+        renders << [method_name, node] if method_name
       end
 
       renders
     end
 
     def render_call?(node)
-      METHODS_TO_PARSE.each { |m| return [true, m] if fcall?(node, m) }
-      false
+      METHODS_TO_PARSE.detect { |m| fcall?(node, m) }
     end
   end
 end


### PR DESCRIPTION
YJIT (at least on Ruby 3.2) doesn't understand expandarray with a non-array, so avoiding returning one avoids a lot of side-exits.

This doesn't particularly matter, since this should only be run at boot time, but it will help us focus on side-exits which are useful.