### PR TITLE
Prism backend + some syntax tree fixes + some ripper fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,4 @@ end
 gem "syntax_tree", platforms: :ruby
 
 # Required only if you want to use the prism backend.
-gem "prism", platforms: :ruby
+gem "prism"

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,6 @@ end
 
 # Required only if you want to use the Syntax Tree backend.
 gem "syntax_tree", platforms: :ruby
+
+# Required only if you want to use the prism backend.
+gem "prism", platforms: :ruby

--- a/lib/actionview_precompiler/ast_parser.rb
+++ b/lib/actionview_precompiler/ast_parser.rb
@@ -13,6 +13,9 @@ module ActionviewPrecompiler
   when "syntax_tree"
     require "actionview_precompiler/ast_parser/syntax_tree"
     ASTParser = SyntaxTreeASTParser
+  when "prism"
+    require "actionview_precompiler/ast_parser/prism"
+    ASTParser = PrismASTParser
   else
     require "actionview_precompiler/ast_parser/ripper"
     ASTParser = RipperASTParser

--- a/lib/actionview_precompiler/ast_parser/prism.rb
+++ b/lib/actionview_precompiler/ast_parser/prism.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "prism"
+
+module ActionviewPrecompiler
+  module PrismASTParser
+    # This error is raised whenever an assumption we made wasn't met by the AST.
+    class CompilationError < StandardError
+    end
+
+    # Each call object is responsible for holding a list of arguments and should
+    # respond to a single #arguments_node method that returns an array of
+    # arguments.
+    class RenderCall
+      attr_reader :argument_nodes
+
+      def initialize(argument_nodes)
+        @argument_nodes = argument_nodes
+      end
+    end
+
+    # This class represents a node in the tree that is returned by the parser
+    # that corresponds to an argument to a render call, or a child of one of
+    # those nodes.
+    class RenderNode
+      attr_reader :node
+
+      def initialize(node)
+        @node = node
+      end
+
+      def call?
+        node.is_a?(Prism::CallNode)
+      end
+
+      def hash?
+        node.is_a?(Prism::HashNode) || node.is_a?(Prism::KeywordHashNode)
+      end
+
+      def string?
+        node.is_a?(Prism::StringNode)
+      end
+
+      def symbol?
+        node.is_a?(Prism::SymbolNode)
+      end
+
+      def variable_reference?
+        case node.type
+        when :class_variable_read_node, :instance_variable_read_node,
+             :global_variable_read_node, :local_variable_read_node
+          true
+        else
+          false
+        end
+      end
+
+      def vcall?
+        node.is_a?(Prism::CallNode) && node.variable_call?
+      end
+
+      # Converts the node into a hash where the keys and values are nodes. This
+      # will raise an error if the hash doesn't match the format we expect or
+      # if the hash contains any splats.
+      def to_hash
+        if hash? && node.elements.all? { |assoc| assoc.is_a?(Prism::AssocNode) && assoc.key.is_a?(Prism::SymbolNode) }
+          node.elements.to_h { |assoc| [RenderNode.new(assoc.key), RenderNode.new(assoc.value)] }
+        else
+          raise CompilationError, "Unexpected node type: #{node.inspect}"
+        end
+      end
+
+      # Converts the node into a string value. Only handles plain string
+      # content, and will raise an error if the node contains interpolation.
+      def to_string
+        if string?
+          node.unescaped
+        else
+          raise CompilationError, "Unexpected node type: #{node.inspect}"
+        end
+      end
+
+      # Converts the node into a symbol value. Only handles labels and plain
+      # symbols, and will raise an error if the node contains interpolation.
+      def to_symbol
+        if symbol?
+          node.unescaped.to_sym
+        else
+          raise CompilationError, "Unexpected node type: #{node.inspect}"
+        end
+      end
+    end
+
+    # This visitor is responsible for visiting the parsed tree and extracting
+    # out the render calls. After visiting the tree, the #render_calls method
+    # will return the hash expected by the #parse_render_nodes method.
+    class RenderVisitor < Prism::Visitor
+      MESSAGE = /\A(render|render_to_string|layout)\z/
+
+      attr_reader :render_calls
+
+      def initialize
+        @render_calls = Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      def visit_call_node(node)
+        if node.name.match?(MESSAGE) && !node.receiver && node.arguments
+          args = node.arguments.arguments.map { |arg| RenderNode.new(arg) }
+          render_calls[node.name.to_sym] << RenderCall.new(args)
+        end
+
+        super
+      end
+    end
+
+    # Main entrypoint into this AST parser variant. It's responsible for
+    # returning a hash of render calls. The keys are the method names, and the
+    # values are arrays of call objects.
+    def self.parse_render_nodes(code)
+      visitor = RenderVisitor.new
+      result = Prism.parse(code)
+
+      if result.success?
+        result.value.accept(visitor)
+        visitor.render_calls
+      else
+        raise CompilationError, "Unable to parse the template"
+      end
+    end
+  end
+end

--- a/lib/actionview_precompiler/ast_parser/ripper.rb
+++ b/lib/actionview_precompiler/ast_parser/ripper.rb
@@ -184,7 +184,11 @@ module ActionviewPrecompiler
       end
 
       def on_paren(content)
-        content
+        if content.type == :list && content.length == 1
+          content[0]
+        else
+          content
+        end
       end
     end
 

--- a/lib/actionview_precompiler/ast_parser/syntax_tree.rb
+++ b/lib/actionview_precompiler/ast_parser/syntax_tree.rb
@@ -57,31 +57,23 @@ module ActionviewPrecompiler
       # will raise an error if the hash doesn't match the format we expect or
       # if the hash contains any splats.
       def to_hash
-        case node
-        in SyntaxTree::HashLiteral[assocs:]
-        in SyntaxTree::BareAssocHash[assocs:]
+        if hash? && node.assocs.all? { |assoc| assoc.is_a?(SyntaxTree::Assoc) }
+          node.assocs.to_h { |assoc| [RenderNode.new(assoc.key), RenderNode.new(assoc.value)] }
         else
           raise CompilationError, "Unexpected node type: #{node.class.name}"
-        end
-
-        assocs.to_h do |assoc|
-          case assoc
-          in SyntaxTree::Assoc[key:, value:]
-            [RenderNode.new(key), RenderNode.new(value)]
-          else
-            raise CompilationError, "Unexpected node type: #{node.class.name}"
-          end
         end
       end
 
       # Converts the node into a string value. Only handles plain string
       # content, and will raise an error if the node contains interpolation.
       def to_string
-        case node
-        in SyntaxTree::StringLiteral[parts: [SyntaxTree::TStringContent[value:]]]
-          value
-        in SyntaxTree::StringLiteral[parts:]
-          raise CompilationError, "Unexpected string parts type: #{parts.inspect}"
+        if string?
+          parts = node.parts
+          if parts.length != 1 || !parts[0].is_a?(SyntaxTree::TStringContent)
+            raise CompilationError, "Unexpected string parts type: #{parts.inspect}"
+          end
+
+          node.parts[0].value
         else
           raise CompilationError, "Unexpected node type: #{node.class.name}"
         end
@@ -90,13 +82,14 @@ module ActionviewPrecompiler
       # Converts the node into a symbol value. Only handles labels and plain
       # symbols, and will raise an error if the node contains interpolation.
       def to_symbol
-        case node
-        in SyntaxTree::Label[value:]
-          value.chomp(":").to_sym
-        in SyntaxTree::SymbolLiteral[value: SyntaxTree::Ident[value:]]
-          value.to_sym
-        in SyntaxTree::SymbolLiteral[value:]
-          raise CompilationError, "Unexpected symbol value type: #{value.inspect}"
+        if node.is_a?(SyntaxTree::Label)
+          node.value.chomp(":").to_sym
+        elsif node.is_a?(SyntaxTree::SymbolLiteral)
+          if !node.value.is_a?(SyntaxTree::Ident)
+            raise CompilationError, "Unexpected symbol value type: #{node.value.inspect}"
+          end
+
+          node.value.to_sym
         else
           raise CompilationError, "Unexpected node type: #{node.class.name}"
         end
@@ -107,7 +100,7 @@ module ActionviewPrecompiler
     # out the render calls. After visiting the tree, the #render_calls method
     # will return the hash expected by the #parse_render_nodes method.
     class RenderVisitor < SyntaxTree::Visitor
-      MESSAGE = /\A(render|render_to_string|layout)\z/
+      MESSAGE = /\A(?:render|render_to_string|layout)\z/
 
       attr_reader :render_calls
 
@@ -116,28 +109,23 @@ module ActionviewPrecompiler
       end
 
       visit_method def visit_command(node)
-        case node
-        in SyntaxTree::Command[
-             message: SyntaxTree::Ident[value: MESSAGE],
-             arguments: SyntaxTree::Args[parts:]
-           ]
-          argument_nodes = parts.map { |part| RenderNode.new(part) }
-          render_calls[$1.to_sym] << RenderCall.new(argument_nodes)
-        else
+        if node.message.is_a?(SyntaxTree::Ident) &&
+           node.message.value.match?(MESSAGE) &&
+           node.arguments.is_a?(SyntaxTree::Args)
+          argument_nodes = node.arguments.parts.map { |part| RenderNode.new(part) }
+          render_calls[node.message.value.to_sym] << RenderCall.new(argument_nodes)
         end
 
         super
       end
 
-      visit_method def visit_fcall(node)
-        case node
-        in SyntaxTree::FCall[
-             value: SyntaxTree::Ident[value: MESSAGE],
-             arguments: SyntaxTree::ArgParen[arguments: SyntaxTree::Args[parts:]]
-           ]
-          argument_nodes = parts.map { |part| RenderNode.new(part) }
-          render_calls[$1.to_sym] << RenderCall.new(argument_nodes)
-        else
+      visit_method def visit_call(node)
+        if node.message.is_a?(SyntaxTree::Ident) &&
+           node.message.value.match?(MESSAGE) &&
+           node.arguments.is_a?(SyntaxTree::ArgParen) &&
+           node.arguments.arguments.is_a?(SyntaxTree::Args)
+          argument_nodes = node.arguments.arguments.parts.map { |part| RenderNode.new(part) }
+          render_calls[node.message.value.to_sym] << RenderCall.new(argument_nodes)
         end
 
         super

--- a/lib/actionview_precompiler/ast_parser/syntax_tree.rb
+++ b/lib/actionview_precompiler/ast_parser/syntax_tree.rb
@@ -144,8 +144,16 @@ module ActionviewPrecompiler
       def render_call(node, arguments)
         render_nodes =
           arguments.parts.map do |part|
-            if part.is_a?(SyntaxTree::Paren) && !part.contents.is_a?(SyntaxTree::Statements)
-              RenderNode.new(part.contents)
+            if part.is_a?(SyntaxTree::Paren)
+              if part.contents.is_a?(SyntaxTree::Statements)
+                if part.contents.body.length == 1
+                  RenderNode.new(part.contents.body[0])
+                else
+                  RenderNode.new(part)
+                end
+              else
+                RenderNode.new(part.contents)
+              end
             else
               RenderNode.new(part)
             end

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -336,6 +336,13 @@ module ActionviewPrecompiler
       require "actionview_precompiler/ast_parser/ruby26"
       Parser = Ruby26ASTParser
     end
+
+    class SyntaxTreeASTRenderParserTest < Minitest::Test
+      include RenderParserTests
+
+      require "actionview_precompiler/ast_parser/syntax_tree"
+      Parser = SyntaxTreeASTParser
+    end
   end
 
   if RUBY_ENGINE == "jruby"

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -353,4 +353,11 @@ module ActionviewPrecompiler
       Parser = JRubyASTParser
     end
   end
+
+  class PrismRenderParserTest < Minitest::Test
+    include RenderParserTests
+
+    require "actionview_precompiler/ast_parser/prism"
+    Parser = PrismASTParser
+  end
 end


### PR DESCRIPTION
This PR does a couple of things.

1. It adds a prism backend for the parser. You can use it with `PRECOMPILER_PARSER=prism`. I've also added a render parser test for it that runs on both CRuby and JRuby (since prism runs just fine on JRuby).
2. It fixes some outdated APIs with syntax tree. Syntax tree has changed since the last time this ran. Unfortunately this wasn't caught because nothing was actually running these tests.
3. It adds a render parser test for syntax tree that runs on CRuby. This was a missing link that I didn't add when I first made the backend. Now things will actually run and catch errors.
4. Fixes a thing with ripper on ruby HEAD where it now forces a statements list inside of parentheses, so one of the tests started failing.