### PR TITLE
Fixes for Ruby 3.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["3.0", "3.1", "3.2", "head"]
+        ruby_version: ["3.0", "3.1", "3.2", "3.3", "head"]
         rails_version: ["main", "6-1-stable", "7-0-stable"]
     runs-on: ubuntu-latest
     name: Test on ${{ matrix.ruby_version }} with Rails ${{ matrix.rails_version }}

--- a/lib/actionview_precompiler/ast_parser/ripper.rb
+++ b/lib/actionview_precompiler/ast_parser/ripper.rb
@@ -184,7 +184,11 @@ module ActionviewPrecompiler
       end
 
       def on_paren(content)
-        content
+        if (content.size == 1) && (content.is_a?(Array))
+          content.first
+        else
+          content
+        end
       end
     end
 

--- a/lib/actionview_precompiler/ast_parser/ruby26.rb
+++ b/lib/actionview_precompiler/ast_parser/ruby26.rb
@@ -74,7 +74,7 @@ module ActionviewPrecompiler
       end
 
       def symbol?
-        type == :LIT && Symbol === children[0]
+        (type == :SYM) || (type == :LIT && Symbol === children[0])
       end
 
       def to_hash

--- a/lib/actionview_precompiler/render_parser.rb
+++ b/lib/actionview_precompiler/render_parser.rb
@@ -128,6 +128,7 @@ module ActionviewPrecompiler
           dependency = node.variable_name
         elsif node.call?
           dependency = node.call_method_name
+          return unless dependency.is_a? String
         else
           return
         end


### PR DESCRIPTION
- `HelperScannerTest` was failing to find any render calls because the first `user` in `user: user` has type of `:SYM` now instead of `:LIT`
- `Ripper` parser was failing on extra whitespace, so I'm just removing one level of nesting in there, not sure if it's a right way to do that
- `Ripper` parser was also failing to parse things like `render FooComponent.new(bar: buzz)` because `call_method_name` in that case was returning the `bar: buzz` part 😬 I don't think that type of renders were supported before anyway, so I just made a guard clause around it