### PR TITLE
make prism the default if it is available

### DIFF
--- a/lib/actionview_precompiler/ast_parser.rb
+++ b/lib/actionview_precompiler/ast_parser.rb
@@ -1,7 +1,13 @@
 module ActionviewPrecompiler
   parser = ENV["PRECOMPILER_PARSER"]
-  parser ||= "jruby" if RUBY_ENGINE == 'jruby'
-  parser ||= "rubyvm_ast" if RUBY_ENGINE == 'ruby'
+
+  begin
+    require "prism"
+    parser ||= "prism"
+  rescue LoadError
+    parser ||= "jruby" if RUBY_ENGINE == 'jruby'
+    parser ||= "rubyvm_ast" if RUBY_ENGINE == 'ruby'
+  end
 
   case parser
   when "rubyvm_ast"


### PR DESCRIPTION
If we can require "prism" and a parser is not explicitly set, use prism.