### PR TITLE
Include filename in compilation errors

### DIFF
--- a/lib/actionview_precompiler.rb
+++ b/lib/actionview_precompiler.rb
@@ -13,6 +13,10 @@ require "actionview_precompiler/parsed_filename"
 module ActionviewPrecompiler
   class Error < StandardError; end
 
+  # This error is raised whenever an assumption we made wasn't met by the AST.
+  class CompilationError < StandardError
+  end
+
   # Allow overriding from ActionView default handlers if necessary
   HANDLERS_FOR_EXTENSION = Hash.new do |h, ext|
     h[ext] = ActionView::Template.handler_for_extension(ext)

--- a/lib/actionview_precompiler/ast_parser/jruby.rb
+++ b/lib/actionview_precompiler/ast_parser/jruby.rb
@@ -88,13 +88,15 @@ module ActionviewPrecompiler
 
     METHODS_TO_PARSE = %i(render render_to_string layout)
 
-    def parse_render_nodes(code)
+    def parse_render_nodes(code, filename)
       node = Node.wrap(JRuby.parse(code))
 
       renders = extract_render_nodes(node)
       renders.group_by(&:first).collect do |method, nodes|
         [ method, nodes.collect { |v| v[1] } ]
       end.to_h
+    rescue Exception
+      raise CompilationError, "Unable to parse the template in #{filename}"
     end
 
     def node?(node)

--- a/lib/actionview_precompiler/ast_parser/prism.rb
+++ b/lib/actionview_precompiler/ast_parser/prism.rb
@@ -4,10 +4,6 @@ require "prism"
 
 module ActionviewPrecompiler
   module PrismASTParser
-    # This error is raised whenever an assumption we made wasn't met by the AST.
-    class CompilationError < StandardError
-    end
-
     # Each call object is responsible for holding a list of arguments and should
     # respond to a single #arguments_node method that returns an array of
     # arguments.
@@ -140,7 +136,7 @@ module ActionviewPrecompiler
     # Main entrypoint into this AST parser variant. It's responsible for
     # returning a hash of render calls. The keys are the method names, and the
     # values are arrays of call objects.
-    def self.parse_render_nodes(code)
+    def self.parse_render_nodes(code, filename)
       visitor = RenderVisitor.new
       result = Prism.parse(code)
 
@@ -148,7 +144,7 @@ module ActionviewPrecompiler
         result.value.accept(visitor)
         visitor.render_calls
       else
-        raise CompilationError, "Unable to parse the template"
+        raise CompilationError, "Unable to parse the template in #{filename}"
       end
     end
   end

--- a/lib/actionview_precompiler/ast_parser/ripper.rb
+++ b/lib/actionview_precompiler/ast_parser/ripper.rb
@@ -153,9 +153,10 @@ module ActionviewPrecompiler
 
       METHODS_TO_PARSE = %w(render render_to_string layout)
 
-      def initialize(*args)
-        super
+      def initialize(filename, *args)
+        super(*args)
 
+        @filename = filename
         @render_calls = []
       end
 
@@ -190,12 +191,16 @@ module ActionviewPrecompiler
           content
         end
       end
+
+      def on_parse_error(*)
+        raise CompilationError, "Unable to parse the template in #{@filename}"
+      end
     end
 
     extend self
 
-    def parse_render_nodes(code)
-      parser = RenderCallParser.new(code)
+    def parse_render_nodes(code, filename)
+      parser = RenderCallParser.new(filename, code)
       parser.parse
 
       parser.render_calls.group_by(&:first).collect do |method, nodes|

--- a/lib/actionview_precompiler/ast_parser/ruby26.rb
+++ b/lib/actionview_precompiler/ast_parser/ruby26.rb
@@ -114,12 +114,14 @@ module ActionviewPrecompiler
 
     METHODS_TO_PARSE = %i(render render_to_string layout)
 
-    def parse_render_nodes(code)
+    def parse_render_nodes(code, filename)
       renders = extract_render_nodes(parse(code))
 
       renders.group_by(&:first).collect do |method, nodes|
         [ method, nodes.collect { |v| v[1] } ]
       end.to_h
+    rescue Exception
+      raise CompilationError, "Unable to parse the template in #{filename}"
     end
 
     def parse(code)

--- a/lib/actionview_precompiler/controller_parser.rb
+++ b/lib/actionview_precompiler/controller_parser.rb
@@ -7,7 +7,7 @@ module ActionviewPrecompiler
     def render_calls
       src = File.read(@filename)
       return [] unless src.include?("render")
-      RenderParser.new(src, from_controller: true).render_calls
+      RenderParser.new(src, @filename, from_controller: true).render_calls
     end
   end
 end

--- a/lib/actionview_precompiler/helper_parser.rb
+++ b/lib/actionview_precompiler/helper_parser.rb
@@ -7,7 +7,7 @@ module ActionviewPrecompiler
     def render_calls
       src = File.read(@filename)
       return [] unless src.include?("render")
-      RenderParser.new(src).render_calls
+      RenderParser.new(src, @filename).render_calls
     end
   end
 end

--- a/lib/actionview_precompiler/render_parser.rb
+++ b/lib/actionview_precompiler/render_parser.rb
@@ -2,14 +2,15 @@ module ActionviewPrecompiler
   RenderCall = Struct.new(:virtual_path, :locals_keys)
 
   class RenderParser
-    def initialize(code, parser: ASTParser, from_controller: false)
+    def initialize(code, filename, parser: ASTParser, from_controller: false)
       @code = code
+      @filename = filename
       @parser = parser
       @from_controller = from_controller
     end
 
     def render_calls
-      render_nodes = @parser.parse_render_nodes(@code)
+      render_nodes = @parser.parse_render_nodes(@code, @filename)
       render_nodes.map do |method, nodes|
         parse_method = case method
         when :layout

--- a/lib/actionview_precompiler/template_parser.rb
+++ b/lib/actionview_precompiler/template_parser.rb
@@ -30,7 +30,7 @@ module ActionviewPrecompiler
       if src.include?("render")
         compiled_source = @handler.call(FakeTemplate.new, File.read(@filename))
         compiled_source = "def _template; #{compiled_source}; end"
-        RenderParser.new(compiled_source).render_calls
+        RenderParser.new(compiled_source, @filename).render_calls
       else
         []
       end

--- a/test/ast_parser_test.rb
+++ b/test/ast_parser_test.rb
@@ -17,8 +17,18 @@ module ActionviewPrecompiler
       assert parse_render_nodes(code).size == 1
     end
 
+    def test_raises_compilation_error
+      code = '<<><><><>>'
+
+      err = assert_raises(ActionviewPrecompiler::CompilationError) do
+        parse_render_nodes(code)
+      end
+
+      assert_equal err.message, "Unable to parse the template in test_file.rb"
+    end
+
     def parse_render_nodes(code)
-      ASTParser.parse_render_nodes(code)
+      ASTParser.parse_render_nodes(code, "test_file.rb")
     end
   end
 end

--- a/test/render_parser_test.rb
+++ b/test/render_parser_test.rb
@@ -329,7 +329,7 @@ module ActionviewPrecompiler
 
     def parse_render_calls(code, **options)
       code = "def foo\n#{code}\nend"
-      RenderParser.new(code, parser: self.class::Parser, **options).render_calls
+      RenderParser.new(code, "test_file.rb", parser: self.class::Parser, **options).render_calls
     end
   end
 


### PR DESCRIPTION
I was working in the GitHub dotcom monolith today and noticed a bunch of CI failures with `CompilationError` stack traces from actionview_precompiler. The failures were happening because of a missed git merge conflict in a Rails template I had mistakenly committed. Unfortunately the `CompilationError`s didn't mention the filename of the template that failed to parse, so I had no idea which template was to blame. I opened up the code and modified it to pass the filename down to where the error was `raise`d and was ultimately able to find and correct the merge conflict. I thought it would be a nice improvement to upstream my changes 😄 